### PR TITLE
Add HTML Auto Tagging

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -442,10 +442,14 @@ vim.keymap.set('n', '<leader>sr', require('telescope.builtin').resume, { desc = 
 vim.defer_fn(function()
   require('nvim-treesitter.configs').setup {
     -- Add languages to be installed here that you want installed for treesitter
-    ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'javascript', 'typescript', 'vimdoc', 'vim', 'bash' },
+    ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'javascript', 'typescript', 'vimdoc', 'vim', 'bash', 'html' },
 
     -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
     auto_install = false,
+
+    autotag = {
+      eable = true,
+    },
 
     highlight = { enable = true },
     indent = { enable = true },

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -25,6 +25,7 @@
   "nvim-lspconfig": { "branch": "master", "commit": "796394fd19fb878e8dbc4fd1e9c9c186ed07a5f4" },
   "nvim-treesitter": { "branch": "master", "commit": "8cd2b230174efbf7b5d9f49fe2f90bda6b5eb16e" },
   "nvim-treesitter-textobjects": { "branch": "master", "commit": "85b9d0cbd4ff901abcda862b50dbb34e0901848b" },
+  "nvim-ts-autotag": { "branch": "main", "commit": "8ae54b90e36ef1fc5267214b30c2cbff71525fe4" },
   "plenary.nvim": { "branch": "master", "commit": "55d9fe89e33efd26f532ef20223e5f9430c8b0c0" },
   "tailwind-tools.nvim": { "branch": "master", "commit": "a95aaf11d9deca884743c9017323c0ffea0015f2" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "6c921ca12321edaa773e324ef64ea301a1d0da62" },

--- a/lua/custom/plugins/autotag.lua
+++ b/lua/custom/plugins/autotag.lua
@@ -1,0 +1,24 @@
+return {
+  'windwp/nvim-ts-autotag',
+  dependencies = { 'nvim-treesitter/nvim-treesitter' },
+  config = function()
+    require('nvim-ts-autotag').setup({
+      opts = {
+        -- Defaults
+        enable_close = true,         -- Auto close tags
+        enable_rename = true,        -- Auto rename pairs of tags
+        enable_close_on_slash = true -- Auto close on trailing </
+      },
+      -- Also override individual filetype configs, these take priority.
+      -- Empty by default, useful if one of the "opts" global settings
+      -- doesn't work well in a specific filetype
+      per_filetype = {
+        ["html"] = {
+          enable_close = true
+        }
+      },
+      lazy = true,
+      event = "VeryLazy",
+    })
+  end,
+}

--- a/lua/custom/plugins/tailwind-tools.lua
+++ b/lua/custom/plugins/tailwind-tools.lua
@@ -4,7 +4,7 @@ return {
   opts = {
     document_color = {
       enabled = true, -- can be toggled by commands
-      kind = 'inline', -- "inline" | "foreground" | "background"
+      kind = 'foreground', -- "inline" | "foreground" | "background"
       inline_symbol = '󰝤 ', -- only used in inline mode
       debounce = 200, -- in milliseconds, only applied in insert mode
     },


### PR DESCRIPTION
Final update for frontend work.

This PR adds support for:
- Auto closing a HTML tag by pressing close `>' character
- When renaming a HTML opening tag, the closing tag now changes as well.